### PR TITLE
Update and fixes for smd-microsoft.css

### DIFF
--- a/smd-microsoft.css
+++ b/smd-microsoft.css
@@ -1,16 +1,31 @@
-@-moz-document regexp('https://.*(msdn|technet|support|blogs|developer|account|answers|docs).microsoft.com/.*'),
-    regexp('https://www.visualstudio.com/.*'),
-    regexp('https://(blogs|insider).windows.com/.*'),regexp('https://www.microsoft.com/.*/(download|windows).*'),regexp('https://login.live.com/.*') {
-/*Simple Modern Dark Microsoft userstyle v1.22
+@-moz-document regexp("https://.*(msdn|technet|support|blogs|developer|account|answers|docs).microsoft.com/.*"), regexp("https://www.visualstudio.com/.*"), regexp("https://(blogs|insider).windows.com/.*"), regexp("https://www.microsoft.com/.*/(download|windows).*"), regexp("https://login.live.com/.*") {
+/*Simple Modern Dark Microsoft userstyle v1.23
 https://userstyles.org/styles/131684
-https://github.com/Zeeex/Simple-Modern-Dark-Microsoft*/
+https://github.com/Zeeex/Simple-Modern-Dark-Microsoft
+some modifications by freMea since v1.23
+*/
 
 html,
 body,
 .CSPvNext,
 .n29d-content {
-	color: #fff !important;
-	background: #000 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAgMAAAANjH3HAAAACVBMVEUaGhohISElJSUh9lebAAAB20lEQVRIx4XWuZXDMAwE0C0SAQtggIIYoAAEU+aKOHhYojTrYP2+QfOW/5QIJOih/q8HwF/pb3EX+UPIveYcQGgEHiu9hI+ihEc5Jz5KBIlRRRaJ1JtoSAl5Hw96hLB1/up1tnIXOck5jZQy+3iU2hAOKSH1JvwxHsp+5TLF5MOl1/MQXsVs1miXc+KDbYydyMeUgpPQreZ7fWidbNhkXNJSeAhc6qHmHD8AYovunYyEACWEbyIhNeB9fRrH3hFi0bGPLuEW7xCNaohw1vAlS805nfsrTspclB/hVdoqusg53eH7FWot+wjYpOViX8KbFFKTwlnzvj65P9H/vD0/hibYBGhPwlPO8TmxRsaxsNnrUmUXpNhirlJMPr6Hqq9k5Xn/8iYQHYIuQsWFC6Z87IOxLxHphSY4SpuiU87xJnJr5axfeRd+lnMExXpEWPpuZ1v7qZdNBOjiHzDREHX5fs5Zz9p6X0vVKbKKchlSl5rv+3p//FJ/PYvoKryI8vs+2G9lzRmnEKkh+BU8yDk515jDj/HAswu7CCz6U/Mxb/PnC9N41ndpU4hUU7JGk/C9PmP/M2xZYdvBW2PObyf1IUiIzoHmHW9yTncliYs9A9tVNppdShfgQaTLMf+j3X723tLeHgAAAABJRU5ErkJggg==) !important;
+  color: #fff !important;
+  background: #000 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAgMAAAANjH3HAAAACVBMVEUaGhohISElJSUh9lebAAAB20lEQVRIx4XWuZXDMAwE0C0SAQtggIIYoAAEU+aKOHhYojTrYP2+QfOW/5QIJOih/q8HwF/pb3EX+UPIveYcQGgEHiu9hI+ihEc5Jz5KBIlRRRaJ1JtoSAl5Hw96hLB1/up1tnIXOck5jZQy+3iU2hAOKSH1JvwxHsp+5TLF5MOl1/MQXsVs1miXc+KDbYydyMeUgpPQreZ7fWidbNhkXNJSeAhc6qHmHD8AYovunYyEACWEbyIhNeB9fRrH3hFi0bGPLuEW7xCNaohw1vAlS805nfsrTspclB/hVdoqusg53eH7FWot+wjYpOViX8KbFFKTwlnzvj65P9H/vD0/hibYBGhPwlPO8TmxRsaxsNnrUmUXpNhirlJMPr6Hqq9k5Xn/8iYQHYIuQsWFC6Z87IOxLxHphSY4SpuiU87xJnJr5axfeRd+lnMExXpEWPpuZ1v7qZdNBOjiHzDREHX5fs5Zz9p6X0vVKbKKchlSl5rv+3p//FJ/PYvoKryI8vs+2G9lzRmnEKkh+BU8yDk515jDj/HAswu7CCz6U/Mxb/PnC9N41ndpU4hUU7JGk/C9PmP/M2xZYdvBW2PObyf1IUiIzoHmHW9yTncliYs9A9tVNppdShfgQaTLMf+j3X723tLeHgAAAABJRU5ErkJggg==) !important;
+}
+/* TITLES ============================== */
+
+h2,
+h3,
+h4,
+h5,
+.main-header .search-field,
+body.blog-id-1 .pagination .page-numbers:not(.dots):not(.current),
+.brandLogo > a {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 150%;
+  color: hsl(205.5, 100%, 60.4%) !important;
+  background-color: inherit !important;
 }
 /* WHITE COLORS ============================== */
 
@@ -38,16 +53,20 @@ h1,
 .unified-baseball-card .baseball-card-affiliate-company,
 .unified-baseball-card-compact-hover .baseball-card-affiliate-company,
 .unified-baseball-card-compact .baseball-card-affiliate-company,
-.threadsnippet .votes {
-	color: #fff !important;
-	background-color: inherit !important;
+.threadsnippet .votes,
+#profile-body span,
+#profile-body div {
+  color: hsl(0, 0%, 90%) !important;
+  background-color: inherit !important;
 }
+
 #ux-header .ux-nav a,
 .ux-nav a:link,
 .ux-nav a:visited {
-	color: #fff;
-	background: inherit;
+  color: #fff;
+  background: inherit;
 }
+
 .forumDetailsTip,
 input,
 textarea,
@@ -65,29 +84,34 @@ textarea,
 .post-vertical,
 .theme-dark .theme-light .c-search input[type=search]:hover,
 .theme-light .c-search input[type=search]:hover,
-.c-auto-suggest .c-menu .c-menu-item>a,
-.c-auto-suggest .c-menu .c-menu-item>span,
-.m-auto-suggest .c-menu .c-menu-item>a,
-.m-auto-suggest .c-menu .c-menu-item>span {
-	color: #fff !important;
-	background-color: #000;
+.c-auto-suggest .c-menu .c-menu-item > a,
+.c-auto-suggest .c-menu .c-menu-item > span,
+.m-auto-suggest .c-menu .c-menu-item > a,
+.m-auto-suggest .c-menu .c-menu-item > span {
+  color: #fff !important;
+  background-color: #000;
 }
+
 #HeaderSearchTextBox,
 #imageMSDN,
 a.n29d-logo {
-	background-color: #fff !important;
+  background-color: #fff !important;
+  color: black !important;
 }
+
 #site-header-global {
-	background: #fff;
+  background: #fff;
 }
+
 .Masthead {
-	background-color: #fff;
+  background-color: #fff;
 }
+
 .breadCrumb,
-.breadCrumb>span>a,
-.breadCrumb>span>a:link,
-.breadCrumb>span>a:hover,
-.breadCrumb>span>a:visited,
+.breadCrumb > span > a,
+.breadCrumb > span > a:link,
+.breadCrumb > span > a:hover,
+.breadCrumb > span > a:visited,
 .LW_CollapsibleArea_Title,
 ul.ops-treecontrol.expandable a,
 input#SearchTextBox,
@@ -95,18 +119,13 @@ input#SearchTextBox,
 .FVBPubDateLabel,
 div.itemCount,
 .SimpleSearchBox2,
-div#tocnav div.tocunselected a,
-div#tocnav div.tocunselected a:link,
-iv#tocnav div.tocunselected a:hover,
-div#tocnav div.tocunselected a:focus,
-div#tocnav div.tocunselected a:visited,
 ul.ops-treecontrol.expandable span.ops-treecontent,
 div.body p span,
 .shell-header-dropdown-content a,
 #ux-header header div.megaBladeToc nav ul.navL1 a,
 #ux-header header div.megaBladeToc nav ul.navL2 a,
 #ux-header header div.megaBladeToc nav ul.navL3 a,
-#breadcrumbDropDownMenu>ul>li>a,
+#breadcrumbDropDownMenu > ul > li > a,
 .type-curation_post .post-title a,
 .type-post:not(tr) .post-title a,
 .type-curation_post .post-title a:hover,
@@ -123,14 +142,16 @@ h5.title-heading-left span,
 .title,
 .heading-md,
 .shell-header a,
-.shell-header {
-	color: #fff !important;
+.shell-header,
+#megabladeMainMenu,
+#megabladeItems h5,
+#megabladeItems > li.inactive > a {
+  color: #fff !important;
 }
+
 a,
-div#body ul#task-nav-list>li>a,
-#page #body ul#task-nav-list>li>a,
-div#body ul#mobile-task-nav-list>li>a,
-#page #body ul#mobile-task-nav-list>li>a,
+div#body ul#mobile-task-nav-list > li > a,
+#page #body ul#mobile-task-nav-list > li > a,
 div#tocNav div a,
 div#tocDropdownMenu div a,
 div#tocNav div a:visited,
@@ -143,11 +164,10 @@ div#tocNav div.current a:visited,
 div#tocDropdownMenu div.current a:visited,
 div#tocNav div.current a:link,
 div#tocDropdownMenu div.current a:link,
-megabladeContainer #megabladeContainerCenter #megabladeMainMenu,
 .communityContentAnnotation,
-#threeColumns>.right #navigationButtons a,
-#threeColumns>.right #navigationButtons a:visited,
-#threeColumns>.right #navigationButtons a:link,
+#threeColumns > .right #navigationButtons a,
+#threeColumns > .right #navigationButtons a:visited,
+#threeColumns > .right #navigationButtons a:link,
 span.username a,
 #quickLinks #quickLinksText span,
 .pln,
@@ -155,16 +175,14 @@ span.username a,
 .unified-baseball-card-mini .profile-mini,
 .unified-baseball-card-mini .profile-mini .profile-mini-points,
 .unified-baseball-card .baseball-card-joined,
-ul.history>li>span.type,
-ul.history>li>span.date,
+ul.history > li > span.type,
+ul.history > li > span.date,
 .section .section-title,
 #brand-name::after,
 h1.post-title,
 .type-curation_post .post-title a,
 .type-post:not(tr) .post-title a,
-.c-universal-header>div:first-child div.js-nav-menu button,
-#megabladeContainer #megabladeContainerCenter.active ul#megabladeItems li.bladeItemWithMenu.active div.navpage,
-#megabladeItems>li>a,
+.c-universal-header > div:first-child div.js-nav-menu button,
 span.loc,
 .download-main-article .row-fluid .brief-description,
 ul.htmldetails,
@@ -185,26 +203,41 @@ span.file-size,
 .msame_Drop_SI a:visited,
 .ask-learn-solve-container .content-text,
 .ask-learn-solve-container .content-title,
-div.home-category-list>div>a,
+div.home-category-list > div > a,
 .header-dropdown-label-home a:visited,
 .header-dropdown-tab-list a:visited,
 #MainContent .statistic-group .statistic-table td,
 #hdr .hdr-signin .hdr-signin-button,
-.c-universal-header>div+div .c-action-trigger,
-.c-universal-header>div+div .c-logo,
-.c-universal-header>div+div .c-uhf-menu a,
-.c-universal-header>div+div .c-uhf-menu button,
-.c-universal-header>div+div .c-uhf-nav-link,
-.c-universal-header>div:first-child .c-uhf-nav-link {
-	color: #fff;
+.c-universal-header > div + div .c-action-trigger,
+.c-universal-header > div + div .c-logo,
+.c-universal-header > div + div .c-uhf-menu a,
+.c-universal-header > div + div .c-uhf-menu button,
+.c-universal-header > div + div .c-uhf-nav-link,
+.c-universal-header > div:first-child .c-uhf-nav-link {
+  color: #fff;
+}
+/* DIM WHITE ============================== */
+
+div#tocNav div.tocLevel > a,
+div#tocnav div.tocunselected div.toclevel > a,
+div#body ul#task-nav-list > li > a,
+#page #body ul#task-nav-list > li > a,
+div#body ul#mobile-task-nav-list > li > a,
+#page #body ul#mobile-task-nav-list > li > a,
+.summaryBox,
+#supportedPlatformText,
+#disclaimer {
+  color: hsl(0, 0%, 70%);
 }
 /* NO BACKGROUND ============================== */
 
 div.msame_Header_name,
-.table th {
-	color: #fff;
-	background: rgba(0, 0, 0, 0);
+.table th,
+#megabladeContainerCenter {
+  color: #fff;
+  background: rgba(0, 0, 0, 0);
 }
+
 .msame_open .msame_Header,
 #DiscussionsTabPane .threadHeader,
 #megabladeContainer .bladeItemMenuContainer,
@@ -226,8 +259,9 @@ div.profile-leaderboard,
 ul.ng-scope li a,
 p span,
 .hero-base.hero-txt-dk.hero-std.hero-single-cell.hero-no-stack {
-	background-color: rgba(0, 0, 0, 0) !important;
+  background-color: rgba(0, 0, 0, 0) !important;
 }
+
 .codeCaption,
 .codeSnippetContainer,
 .codeSnippetContainerTabSingle,
@@ -252,9 +286,7 @@ div.kb-notice-section.section.ng-scope,
 div.search-container.other,
 div.container.quick-nav.ng-scope.other,
 #JelloWrapper,
-.shell-header-dropdown-label>a,
-#megabladeContainer #megabladeContainerCenter.active #megabladeMainMenu,
-#megabladeContainer #megabladeContainerCenter #megabladeMainMenu:hover,
+.shell-header-dropdown-label > a,
 #page,
 #BodyBackground,
 div.shell-header,
@@ -273,13 +305,14 @@ table.home-header,
 div#BrandLogo,
 #journeys,
 .journey-step,
-.journey-step-elements li>a,
-.journey-step-elements li>a:hover,
+.journey-step-elements li > a,
+.journey-step-elements li > a:hover,
 .features,
 .siteResources,
 #hdr {
-	background: rgba(0, 0, 0, 0);
+  background: rgba(0, 0, 0, 0);
 }
+
 .n29d-nav li.n29d-active a,
 .n29d-nav a,
 .n29d-nav,
@@ -287,21 +320,23 @@ div#BrandLogo,
 .n29d-header ul,
 .n29d-nav-wrapper,
 .n29d-nav li {
-	color: #fff !important;
-	background: rgba(0, 0, 0, 0);
+  color: #fff !important;
+  background: rgba(0, 0, 0, 0);
 }
+
 .hljs {
-	color: #fff;
-	background: rgba(0, 0, 0, 0);
+  color: #fff;
+  background: rgba(0, 0, 0, 0);
 }
+
 div#msdn-technet-en-thread div#threadPageContentContainer {
-	border-left: 4px solid #35ff8b;
+  border-left: 4px solid hsl(205.5, 100%, 60.4%);
 }
 /* BLACK COLORS ============================== */
 
 .unified-baseball-card .baseball-card-header .baseball-card-summary,
 .unified-baseball-card .baseball-card-header .crop,
-.scriptcode .title>span,
+.scriptcode .title > span,
 .main-nav,
 .post-archive,
 .web-feature[open] .web-feature__toggle,
@@ -313,9 +348,13 @@ button[type=menu]+menu menuitem,
 div#free-dev-offers,
 .fusion-fullwidth.fullwidth-box.fusion-fullwidth-1.fusion-parallax-none.nonhundred-percent-fullwidth,
 .fusion-fullwidth.fullwidth-box.fusion-fullwidth-3.fusion-parallax-none.nonhundred-percent-fullwidth,
-.c-universal-header>div+div {
-	background-color: #000 !important;
+.c-universal-header > div + div,
+#megabladeMainMenu:hover,
+#megabladeContainerCenter.active #megabladeMainMenu,
+#megabladeContainer #megabladeContainerCenter.active ul#megabladeItems li.bladeItemWithMenu.active div.navpage {
+  background-color: #000 !important;
 }
+
 #mobileMenu #tocDropdownMenuButton #tocDropdownMenu,
 #mobileMenu #tocDropdownMenuButton div.tocLabel,
 div#body ul#mobile-task-nav-list,
@@ -323,15 +362,15 @@ div#body ul#mobile-task-nav-list,
 .alert-band .alert.alert-info,
 .content-article .sbody-error,
 #shell-header .shell-header-nav .shell-header-dropdown-tab .shell-header-dropdown-tab-label a,
-.shell-header-dropdown.active .shell-header-dropdown-label>a,
+.shell-header-dropdown.active .shell-header-dropdown-label > a,
 #Fragment_HeroHeadlines,
 #Fragment_ResourceBandcontent,
 .navL1,
 .navL2,
 .inactive,
-#ux-header header div.row nav ul.navL1>li.active>a,
-#ux-header header div.row nav ul.navL2>li.active>a,
-#ux-header header div.row nav ul.navL3>li.active>a,
+#ux-header header div.row nav ul.navL1 > li.active > a,
+#ux-header header div.row nav ul.navL2 > li.active > a,
+#ux-header header div.row nav ul.navL3 > li.active > a,
 #ux-header header div.megaBladeToc nav ul.navL1,
 #ux-header header div.megaBladeToc nav ul.navL2,
 #ux-header header div.megaBladeToc nav ul.navL3,
@@ -343,8 +382,8 @@ div#body ul#mobile-task-nav-list,
 .shell-header-user #meControl .msame_Header:focus,
 .msame_Drop_content,
 .c-universal-header > div:first-child .c-uhf-menu > ul,
-.c-universal-header > div:first-child .c-uhf-menu > ul > li >:focus,
-.c-universal-header > div:first-child .c-uhf-menu > ul > li >:hover,
+.c-universal-header > div:first-child .c-uhf-menu > ul > li > :focus,
+.c-universal-header > div:first-child .c-uhf-menu > ul > li > :hover,
 .c-universal-header > div:first-child .c-uhf-menu > ul > li > [aria-expanded="true"],
 .c-universal-header > div:first-child .c-uhf-menu > ul > li > ul,
 .c-universal-header > div:first-child .c-uhf-menu > ul > li > ul:focus,
@@ -361,7 +400,7 @@ div.NOTE,
 ul.popup,
 div.post-content.column,
 div.sidebar.column,
-.c-universal-header>div:first-child,
+.c-universal-header > div:first-child,
 .dropNavForSearch ul,
 #Fragment_HeroHeadlines,
 #hdr-fb-main,
@@ -373,15 +412,16 @@ li.message div.body blockquote,
 .rankings-right .rank-cell,
 #MainContent .statistic-group,
 .ContextMenuPanel,
-.c-universal-footer>div,
-.c-universal-footer>section,
+.c-universal-footer > div,
+.c-universal-footer > section,
 .c-universal-footer nav,
 .c-universal-header>div+div .c-uhf-menu>button[aria-expanded=true],
-.c-universal-header>div+div .c-uhf-menu>ul,
-.c-universal-header>div+div .c-uhf-menu>ul>li>ul,
+.c-universal-header > div + div .c-uhf-menu > ul,
+.c-universal-header > div + div .c-uhf-menu > ul > li > ul,
 .theme-light .c-search input[type=search]:focus {
-	background: #000;
+  background: #000;
 }
+
 div#eula,
 #eulaPage,
 .posts-filter,
@@ -434,25 +474,28 @@ textarea:focus,
 .SearchBar .productsatoz,
 .SearchBar .productsbycategory,
 .defaulttext,
-.srchbox .stxtcell>input,
+.srchbox .stxtcell > input,
 .srchbox #searchImageCell {
-	color: #fff !important;
-	background-color: #000;
+  color: #fff !important;
+  background-color: #000;
 }
+
 #ux-header header div.row #drawer *,
 #breadcrumbDropDownMenu {
-	color: #fff;
-	background-color: #000;
+  color: #fff;
+  background-color: #000;
 }
+
 input,
 optgroup,
 select,
 textarea,
 ul.side-nav .selected-nav a {
-	color: #000;
+  color: #000;
 }
+
 li.box-title p {
-	color: #000!important;
+  color: #000 !important;
 }
 /* GRAY COLORS ============================== */
 
@@ -467,69 +510,83 @@ li.box-title p {
 .dlc-v73 .dlc-hp-icons a:hover,
 .dlc-v73 .dlc-hp-icons a:active,
 .mscom-accordion .mscom-accordion-item-link:hover {
-	background-color: gray;
+  background-color: gray;
 }
-li.message div.body div.quote {
-	background-color: gray !important;
+
+li.message div.body div.quote,
+#megabladeItems > li.inactive > a {
+  background-color: gray !important;
 }
 /* BORDERS ============================== */
 
-.editorPickedItem>td {
-	border-top: 6px solid gray;
+.editorPickedItem > td {
+  border-top: 6px solid gray;
 }
+
 input[type="search"] {
-	border: 1px solid #424242;
+  border: 1px solid #424242;
 }
+
 .search-field {
-	border: 1px solid #35ff8b;
+  border: 1px solid hsl(205.5, 100%, 60.4%);
 }
+
 body.blog-id-1 .main-footer,
 body.blog-id-2 .main-footer {
-	border-top-color: #35ff8b;
+  border-top-color: hsl(205.5, 100%, 60.4%);
 }
-div.answers>h3,
-div.replies>h3 {
-	border-top: solid 2px #35ff8b;
+
+div.answers > h3,
+div.replies > h3 {
+  border-top: solid 2px hsl(205.5, 100%, 60.4%);
 }
-div#body ul#task-nav-list>li.active,
-#page #body ul#task-nav-list>li.active,
-div#body ul#mobile-task-nav-list>li.active,
-#page #body ul#mobile-task-nav-list>li.active {
-	border-left: solid 3px #35ff8b;
+
+div#body ul#task-nav-list > li.active,
+#page #body ul#task-nav-list > li.active,
+div#body ul#mobile-task-nav-list > li.active,
+#page #body ul#mobile-task-nav-list > li.active {
+  border-left: solid 3px hsl(205.5, 100%, 60.4%);
 }
+
 div#tocnav div.tocselected,
 ul.ops-treecontrol.expandable .ops-treelevel-0.ops-treenode-related,
 div#tocNav div.tocSelected,
 div#tocDropdownMenu div.tocSelected,
-#breadcrumbDropDownMenu>ul>li.current {
-	border-left: 4px solid #35ff8b;
-	background-color: #000;
+#breadcrumbDropDownMenu > ul > li.current {
+  border-left: 4px solid hsl(205.5, 100%, 60.4%);
+  background-color: #000;
+  padding-right: 5px;
 }
+
 summary {
-	border-bottom: 1px solid gainsboro;
+  border-bottom: 1px solid gainsboro;
 }
+
 div#rightNavigationMenu div#indoc_toc ul#indoc_toclist li.active {
-	border-left: solid 3px #35ff8b;
+  border-left: solid 3px hsl(205.5, 100%, 60.4%);
 }
-#ux-header header div.row nav ul.navL1>li>a,
-#ux-header header div.row nav ul.navL2>li>a,
-#ux-header header div.row nav ul.navL3>li>a {
-	border-bottom: solid 1px #2e2e2e;
+
+#ux-header header div.row nav ul.navL1 > li > a,
+#ux-header header div.row nav ul.navL2 > li > a,
+#ux-header header div.row nav ul.navL3 > li > a {
+  border-bottom: solid 1px #2e2e2e;
 }
-#ux-header header div.toc nav ul.navL1>li.current>a:hover {
-	border-bottom: solid 5px #35ff8b
+
+#ux-header header div.toc nav ul.navL1 > li.current > a:hover {
+  border-bottom: solid 5px hsl(205.5, 100%, 60.4%);
 }
+
 li.message div.voting,
 .n29d-search-header {
-	border: 1px solid #999!important;
+  border: 1px solid #999 !important;
 }
 /* END BORDERS ============================== */
 /* TABLE HEADER */
 
 div.alert th,
 th {
-	background-color: #3b3b3b;
-	color: #fff;
+  background-color: #3b3b3b;
+  color: #fff;
 }
 /* LINKS - ACCENT ============================== */
 
@@ -540,13 +597,13 @@ div#rightNavigationMenu div#indoc_toc ul#indoc_toclist li.active a,
 .function-area .ops-socialsharing-dropdownbtn:focus,
 .function-area .ops-socialsharing-dropdownbtn:hover,
 ul.side-nav .nav-link a,
-div#body ul#task-nav-list>li.active>a,
-#page #body ul#task-nav-list>li.active>a,
-div#body ul#mobile-task-nav-list>li.active>a,
-#page #body ul#mobile-task-nav-list>li.active>a,
+div#body ul#task-nav-list > li.active > a,
+#page #body ul#task-nav-list > li.active > a,
+div#body ul#mobile-task-nav-list > li.active > a,
+#page #body ul#mobile-task-nav-list > li.active > a,
 .msame_unauth .msame_Header_name:hover,
-#eulaPage .eulaPagebuttons>button,
-div.profile-leaderboard div.profile-leaderboard-item>div.profile-leaderboard-container .profile-leaderboard-value,
+#eulaPage .eulaPagebuttons > button,
+div.profile-leaderboard div.profile-leaderboard-item > div.profile-leaderboard-container .profile-leaderboard-value,
 .featured-post a.post-title,
 a:link,
 .topic a,
@@ -570,7 +627,7 @@ div#MainContent a:visited,
 div#MainContent a,
 div#MainContent a:link,
 .quick-nav a,
-.has-site-navigation .main-nav .container>ul>li.ms-current-blog>a,
+.has-site-navigation .main-nav .container > ul > li.ms-current-blog > a,
 .button--icon,
 .button--search:hover,
 .button--text,
@@ -592,36 +649,29 @@ a#shell-header-shopping-cart,
 .features a:active,
 .features a:link,
 .features a:visited,
-.c-universal-header>div:first-child .c-uhf-menu a,
-.c-universal-header>div:first-child .c-uhf-menu button,
+.c-universal-header > div:first-child .c-uhf-menu a,
+.c-universal-header > div:first-child .c-uhf-menu button,
 #bodyContentPane a,
 a.mscom-link.c-call-to-action.c-glyph span,
 .c-glyph:after,
 .c-glyph:before,
 .c-glyph:hover:after,
-.c-glyph:hover:before {
-	color: #35ff8b;
+.c-glyph:hover:before,
+#profile-body .statistic-header {
+  color: hsl(205.5, 100%, 60.4%);
 }
+
 ul.side-nav .selected-nav,
 div.replies div.messageIcon.status.proposed,
 .auto-suggest-results ul li:hover,
 .auto-suggest-results ul li.selected,
 .anchor-top {
-	background-color: #35ff8b;
+  background-color: hsl(205.5, 100%, 60.4%);
 }
-/* TITLES ============================== */
+/*  FORCE ACCENT COLOR FOR SOME ITEMS =========== */
 
-h2,
-h3,
-h4,
-h5,
-.main-header .search-field,
-body.blog-id-1 .pagination .page-numbers:not(.dots):not(.current) {
-	font-weight: bold;
-	text-transform: uppercase;
-	font-size: 150%;
-	color: #35ff8b !important;
-	background-color: inherit !important;
+#profile-body .statistic-header {
+  color: hsl(205.5, 100%, 60.4%) !important;
 }
 /* INVERTED BUTTON ============================== */
 
@@ -646,206 +696,303 @@ body.blog-id-1 .pagination .page-numbers.current,
 .shell-header-dropdown-tab .shell-header-dropdown-tab-label:hover,
 .shell-header-dropdown-tab .shell-header-dropdown-tab-label:focus,
 .shell-header-dropdown-label a:hover,
-#ux-header header div.toc nav ul.navL1>li.current.active>a,
-#ux-header header div.toc nav ul.navL2>li.current.active>a,
-#ux-header header div.row nav ul.navL1>li.inactive>a:hover,
-#ux-header header div.row nav ul.navL2>li.inactive>a:hover,
-#ux-header header div.row nav ul.navL3>li.inactive>a:hover,
+#ux-header header div.toc nav ul.navL1 > li.current.active > a,
+#ux-header header div.toc nav ul.navL2 > li.current.active > a,
+#ux-header header div.row nav ul.navL1 > li.inactive > a:hover,
+#ux-header header div.row nav ul.navL2 > li.inactive > a:hover,
+#ux-header header div.row nav ul.navL3 > li.inactive > a:hover,
 .shell-header a:hover,
 button:hover,
-.c-auto-suggest .c-menu .c-menu-item>a:hover,
-.c-auto-suggest .c-menu .c-menu-item>span:hover,
-.m-auto-suggest .c-menu .c-menu-item>a:hover,
-.m-auto-suggest .c-menu .c-menu-item>span:hover,
-.c-universal-header>div:first-child .c-uhf-menu>ul>li>ul:hover,
+.c-auto-suggest .c-menu .c-menu-item > a:hover,
+.c-auto-suggest .c-menu .c-menu-item > span:hover,
+.m-auto-suggest .c-menu .c-menu-item > a:hover,
+.m-auto-suggest .c-menu .c-menu-item > span:hover,
+.c-universal-header > div:first-child .c-uhf-menu > ul > li > ul:hover,
 .pivotTabs li.selected,
 #hdr-nav-large-primary a:hover,
 .c-universal-header>div+div .c-uhf-menu>ul>li>[aria-expanded=true],
-.c-universal-header>div+div .c-uhf-menu>ul>li>a:focus,
-.c-universal-header>div+div .c-uhf-menu>ul>li>a:hover,
-.c-universal-header>div+div .c-uhf-menu>ul>li>button:focus,
-.c-universal-header>div+div .c-uhf-menu>ul>li>button:hover,
-.c-universal-header>div+div .c-uhf-menu>ul>li>ul>li:focus,
-.c-universal-header>div+div .c-uhf-menu>ul>li>ul>li:hover,
+.c-universal-header > div + div .c-uhf-menu > ul > li > a:focus,
+.c-universal-header > div + div .c-uhf-menu > ul > li > a:hover,
+.c-universal-header > div + div .c-uhf-menu > ul > li > button:focus,
+.c-universal-header > div + div .c-uhf-menu > ul > li > button:hover,
+.c-universal-header > div + div .c-uhf-menu > ul > li > ul > li:focus,
+.c-universal-header > div + div .c-uhf-menu > ul > li > ul > li:hover,
 body #headerUniversalHeader .c-call-to-action.c-glyph {
-	background-color: #35ff8b !important;
-	color: #000 !important;
+  background-color: hsl(205.5, 100%, 60.4%) !important;
+  color: #000 !important;
 }
 /* END INVERTED BUTTON ============================== */
 
 a:hover,
 .topic a:active,
 .topic a:hover {
-	color: gainsboro !important;
+  color: gainsboro !important;
 }
+
 .placement__icon {
-	color: #35ff8b !important;
-	background-color: #000 !important;
+  color: hsl(205.5, 100%, 60.4%) !important;
+  background-color: #000 !important;
 }
 /* GRAY BUTTON ============================== */
 
 #projectPage #Downloads .button {
-	background-color: #5d5d5d !important;
+  background-color: #5d5d5d !important;
 }
 /* HOVERED BUTTON ============================== */
 
 #projectPage #Downloads .button:hover {
-	background-color: #5d5d5d !important;
-	color: #35ff8b !important;
+  background-color: #5d5d5d !important;
+  color: hsl(205.5, 100%, 60.4%) !important;
 }
+
 button {
-	background-color: rgba(0, 0, 0, 0) !important;
-	color: #35ff8b !important;
+  background-color: rgba(0, 0, 0, 0) !important;
+  color: hsl(205.5, 100%, 60.4%) !important;
 }
 /* END COLOR ============================== */
 
-div#rightNavigationMenu>div a:visited {
-	color: #a0a0a0;
+div#rightNavigationMenu > div a:visited {
+  color: #a0a0a0;
 }
+
 #search-box .search-container,
 .Masthead,
 #contributeSection,
 #sideNav #contributeSection h3,
 .sidebar #contributeSection h3,
 #contributeSection h3 {
-	background-color: inherit !important;
+  background-color: inherit !important;
 }
+
 #navigationButtons ins.print,
 #navigationButtons ins.export,
 #navigationButtons ins.share,
 #navigationButtons ins.contribute,
 .LW_CollapsibleArea_Anchor_Img {
-	background-color: #35ff8b;
+  background-color: hsl(205.5, 100%, 60.4%);
 }
+
 #vsPanel {
-	background-color: #212121;
+  background-color: #212121;
 }
 /* Version of .NET framework under the main header */
 
 #curversion {
-	color: #9b9b9b;
+  color: #9b9b9b;
 }
+
 h2.entry-title a,
 #posts-query-type .filter-option.selected a,
-div#body ul#task-nav-list>li.nav-header,
-#page #body ul#task-nav-list>li.nav-header,
-div#body ul#mobile-task-nav-list>li.nav-header,
-#page #body ul#mobile-task-nav-list>li.nav-header,
+div#body ul#task-nav-list > li.nav-header,
+#page #body ul#task-nav-list > li.nav-header,
+div#body ul#mobile-task-nav-list > li.nav-header,
+#page #body ul#mobile-task-nav-list > li.nav-header,
 div.section p,
 div.helpbubble p,
 div.helpbubble ul,
-a.author>abbr,
+a.author > abbr,
 .section.item-section .section-title,
 .page-title-header .page-subtitle,
 .breadcrumb,
-.breadcrumb>li a,
-.breadcrumb>li a:visited,
-.breadcrumb>li+li:before,
+.breadcrumb > li a,
+.breadcrumb > li a:visited,
+.breadcrumb > li + li:before,
 .blog-list span,
 .blog-list a:hover,
 .event-list span,
 .event-list a:hover {
-	color: inherit;
+  color: inherit;
 }
 /* msdn sub ======*/
 
 .n29d-nav a {
-	color: #212121;
+  color: #212121;
 }
-.DL_list li:nth-child(even) {
-	background-color: #212121;
-}
-/* technet ==================================== */
 
-#megabladeItems>li.active>a {
-	background-color: #575757;
+.DL_list li:nth-child(even) {
+  background-color: #212121;
 }
-div#tocNav a.tocExpanded,
+/* technet and msdn ==================================== */
+
+#megabladeItems > li.active > a {
+  background-color: #575757;
+}
+/********** Table of contents*/
+
+#tocNav a.tocExpanded,
+#tocnav a.toc_expanded,
 div#tocDropdownMenu a.tocExpanded,
-div#tocNav a.tocCollapsed {
-	background: url(https://technet.microsoft.com/Areas/Epx/Content/Images/ImageSprite.png?v=636164956049129837) no-repeat scroll -1262px -3px;
-	width: 16px;
-	height: 16px;
+#megabladeMainMenu:after {
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAU3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHja40qtyEzjUgADExMuE1NzCzNLMzMDIDCxNLE0SgQyLAwgwAhMGhqYgEkoxwDGQBHngktAARcATu4UINhypRgAAAAJcEhZcwAAEGUAABBlAdEuKBEAAACKSURBVDjL3ZIxDoJAEEWXw9BaUEGoLLFUrgC0nsJLcglILIzF+xZgMpmwiJT8cmfe25nshnCMSEqACkh/9QIn4OwPH5IEjECxAl+AF1PutvDUnJjkC5u+3hYbACfJV+A3cPU3dFYiaQDyCFzHduwWJtkGmxdp3STb4ZjkL9hLZvi264MBJZCFY+cDxLIdTU4i8BsAAAAASUVORK5CYII=') no-repeat scroll !important;
+  background-color: transparent !important;
+  height: 12px !important;
+  width: 12px !important;
+  margin-top: 5px !important;
+  background-size: 12px !important;
+}
+
+#tocNav a.tocCollapsed,
+#tocnav a.toc_collapsed,
+div#tocDropdownMenu a.tocCollapsed {
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAU3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHja40qtyEzjUgADExMuE1NzCzNLMzMDIDCxNLE0SgQyLAwgwAhMGhqYgEkoxwDGQBHngktAARcATu4UINhypRgAAAAJcEhZcwAAEGUAABBlAdEuKBEAAACKSURBVDjL3ZIxDoJAEEWXw9BaUEGoLLFUrgC0nsJLcglILIzF+xZgMpmwiJT8cmfe25nshnCMSEqACkh/9QIn4OwPH5IEjECxAl+AF1PutvDUnJjkC5u+3hYbACfJV+A3cPU3dFYiaQDyCFzHduwWJtkGmxdp3STb4ZjkL9hLZvi264MBJZCFY+cDxLIdTU4i8BsAAAAASUVORK5CYII=') no-repeat scroll !important;
+  background-color: transparent !important;
+  height: 8px !important;
+  width: 8px !important;
+  margin-top: 7px !important;
+  background-size: 8px !important;
+  transform: rotate(-90deg) !important;
+}
+
+#tocnav div.tocselected a.toc_collapsed {
+  margin-top: 0px !important;
+}
+
+#megabladeMainMenu:after {
+  margin: 5px !important;
+}
+
+#tocNav a.tocExpanded + a {
+  color: hsl(205.5, 100%, 60.4%) !important;
+}
+
+#tocNav div.tocLevel.current,
+div#tocnav div.toclevel.current {
+  background: hsl(205.5, 100%, 60.4%) !important;
+  border-radius: 3px 0 0 3px !important;
+  margin-right: -5px !important;
+  margin-left: -5px !important;
+  padding: 5px !important;
+}
+
+div#tocNav div.tocLevel.current > a,
+div#tocnav div.toclevel.current > a {
+  color: white !important;
+  font-weight: bold !important;
 }
 /* blogs.technet======================*/
 
 .widget_tag_cloud a {
-	background-color: #2a2a2a;
+  background-color: #2a2a2a;
+}
+/* gallery.technet.microsoft.com======*/
+/* tables */
+
+tr.oddRow {
+  background: hsl(0, 0%, 10%) !important;
+}
+
+tr.evenRow {
+  background: hsl(0, 0%, 15%) !important;
+}
+
+tr.oddRow td,
+tr.evenRow td {
+  color: hsl(0, 0%, 90%);
 }
 /* social.technet====================*/
 
 div.unified-baseball-card,
 .unified-baseball-card-compact,
 .unified-baseball-card-hover div.unified-baseball-card {
-	background-color: #3e3e3e;
+  background-color: #3e3e3e;
 }
 /* support-ms */
 
 .ms-productpages .pp-section-header {
-	background-color: gainsboro;
+  background-color: gainsboro;
 }
+
 .single .entry-meta,
 .author-bio-box h6,
 .internav a:hover,
 .internav a:focus,
 .kb-article .kb-notice-section {
-	background: inherit;
+  background: inherit;
 }
 /* developer-ms */
 
 div#tocnav div.tocselected a,
 div#tocnav div.tocselected a:link,
 div#tocnav div.tocselected a:visited {
-	color: gainsboro;
-	padding-left: 12px;
+  color: gainsboro;
+  padding-left: 12px;
 }
-div#rightNavigationMenu>div a {
-	color: #fff;
-	display: block;
-	margin-bottom: 10px;
+
+div#rightNavigationMenu > div a {
+  color: #fff;
+  display: block;
+  margin-bottom: 10px;
 }
+
 div#rightNavigationMenu div#indoc_toc div#indoc_title,
 div#rightNavigationMenu div#indoc_toc ul#indoc_toclist li {
-	color: #fff;
-	font-weight: 600;
+  color: #fff;
+  font-weight: 600;
 }
 /* Ordinary code color */
 
 [style*="Black"] {
-	color: #dcdcdc !important;
+  color: #dcdcdc !important;
 }
 /* Keywords */
 
 [style*="Blue"] {
-	color: #569cd6 !important;
+  color: #569cd6 !important;
 }
 /* Comments */
 
 [style*="Green"] {
-	color: #57a64a !important;
+  color: #57a64a !important;
 }
 /* String literals */
 
 [style*="A31515"] {
-	color: #d69d85 !important;
+  color: #d69d85 !important;
 }
 /* Inline code */
 
 .code {
-	color: #4ec9b0 !important;
+  color: #4ec9b0 !important;
+}
+/* Other code color */
+
+.hljs {
+  color: hsl(200, 0%, 80%) !important;
+}
+
+.hljs-meta {
+  color: hsl(100, 50%, 50%) !important;
+}
+
+.hljs-attribute,
+.hljs-attr {
+  color: hsl(50, 80%, 50%) !important;
+}
+
+.hljs-literal {
+  color: hsl(180, 80%, 50%) !important;
+}
+
+.hljs-built_in {
+  color: hsl(200, 100%, 50%) !important;
+}
+
+.hljs-number {
+  color: hsl(280, 100%, 50%) !important;
 }
 /* JUNK ======*/
 
 div.alert {
-	background-color: rgba(0, 0, 0, 0);
-	color: #a0dfe4 !important;
-	font-style: italic;
+  background-color: rgba(0, 0, 0, 0);
+  color: #a0dfe4 !important;
+  font-style: italic;
 }
+
 #nrSurvey,
 #PrivacyBanner,
 #archiveDisclaimer,
 .sockWrapper,
-.stdr-container>.stdr-vote,
+.stdr-container > .stdr-vote,
 .epb-container.active,
 .jumbotron,
 .jumbotron-hero,
@@ -862,52 +1009,64 @@ div#dlc-hp-hero-slideshow,
 div#PrivacyBanner,
 #hero-content,
 .m-alert.f-information {
-	display: none !important;
+  display: none !important;
 }
+
 div.replies {
-	border-top: none !important;
+  border-top: none !important;
 }
+
 #BrandDisplayText {
-	display: block;
+  display: block;
 }
 /* account-ms */
 
 #srv_shellHeaderMicrosoftLogo img {
-	background-color: #c7c7c7;
+  background-color: #c7c7c7;
 }
+
 div.back-to-top-wrap {
-	background-color: #2a2a2a;
+  background-color: #2a2a2a;
 }
+
 font font p {
-	color: #0088ff;
+  color: #0088ff;
 }
 /* FONT TWEAKS */
 
 h3.sbody-h3 {
-	font-weight: bold;
-	text-transform: uppercase;
-	font-size: 150%;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 150%;
 }
+
 h4.sbody-h4 {
-	font-variant: small-caps;
-	font-size: 150%;
+  font-variant: small-caps;
+  font-size: 150%;
 }
 /* CODE BACKGROUND */
+
+pre {
+  border: solid hsl(200, 0%, 20%) 1px !important;
+}
 
 .codeSnippetContainerCode,
 pre,
 code {
-	background-color: #222324;
+  background: hsl(200, 0%, 10%) !important;
 }
+
 .shell-category-header.cat-theme-blue {
-	background-color: #383838;
+  background-color: #383838;
 }
+
 blockquote,
 #answers.answers {
-	background: #2d2d2d;
+  background: #2d2d2d;
 }
 /* PREVENT SCROLL JITTER */
 
 div#content {
-	padding-top: 0 !important;
-}}
+  padding-top: 0 !important;
+}
+}


### PR DESCRIPTION
**Warning: I used the blue accent color to edit.**

# GENERAL

- change : accent HEX color to HSL format (easier to create sets of matching colors in the future)
    - New blue color name is `hsl(205.5, 100%, 60.4%)`

# social.technet.microsoft.com

_url sample : https://social.technet.microsoft.com/Profile/ken%20sweet_

- Fix profile pages: dark grey text on dark background was unvisible

# technet.microsoft.com

_url sample: https://technet.microsoft.com/en-us/library/mt267544.aspx_

- Top Menu
   - Fix : #megabladeMainMenu visibility
- Page Title
   - Fix : .brandLogo visibility
- table of content (on the left)
   - Fix : arrows
   - change : dim white color for non selected content (enhance main content focus)
   - change : current section is much more noticeable

# msdn.microsoft.com

_url sample : https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.diagnostics/export-counter_

- Search Input #HeaderSearchTextBox
   - Fix : white text on white background
- table of content (on the left)
   - Fix : arrows
   - change : dim white color for non selected content (enhance main content focus)
   - change : current section is much more noticeable
- code
   - change : improve visibility and syntax color support
- In this article (tree on right)
   - change : dim white color for non selected content (enhance main content focus)

# gallery.technet.microsoft.com

_url sample : https://gallery.technet.microsoft.com_

- summary
   - change : dim white color for non selected content (enhance main content focus)
- description page for snippet
   - fix : table named "Verified on the following platforms" was white